### PR TITLE
Replace 'killall -9' with 'killall' for non-Windows OSes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var windows = require('os').platform() === 'win32';
 var exec = require('child_process').exec;
 
 var commands = ['mongod', 'mongo', 'mongos'].map(function(name) {
-  return windows ? 'taskkill /F /IM ' + name + '.exe' : 'killall -9 ' + name;
+  return windows ? 'taskkill /F /IM ' + name + '.exe' : 'killall ' + name;
 });
 
 module.exports = function(done) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,9 +12,9 @@ describe('kill-mongodb', function() {
       ]);
     } else {
       assert.deepEqual(kill.commands, [
-        'killall -9 mongod',
-        'killall -9 mongo',
-        'killall -9 mongos'
+        'killall mongod',
+        'killall mongo',
+        'killall mongos'
       ]);
     }
   });


### PR DESCRIPTION
As per the current MongoDB docs and issue:
https://docs.mongodb.com/v3.4/tutorial/manage-mongodb-processes/#use-kill
https://github.com/mongodb-js/kill-mongodb/issues/6

[npm tells me](https://www.npmjs.com/browse/depended/kill-mongodb) its also used by https://www.npmjs.com/package/mj and [I identified runner originally](https://github.com/mongodb-js/runner/blob/414359f88d6f2f9d23badbbcaa6b2028f4445656/package.json#L58-L62
) which are both ours. It appears to otherwise not directly be required anywhere.